### PR TITLE
Add class attributes to input fields in bootstrap3 renderer

### DIFF
--- a/src/formidable/render/bootstrap3.cljx
+++ b/src/formidable/render/bootstrap3.cljx
@@ -66,7 +66,7 @@
                     (= :time-select (:type field)))
         field (assoc field
                 :id field-id
-                :class (if checkbox? "" "form-control"))
+                :class (str (:class field) (if checkbox? "" " form-control")))
         submit? (= :submit (:type field))
         field (if submit?
                 (assoc field :class (str (:class field)


### PR DESCRIPTION
The bootstrap renderer omitted the form field `:class` arguments from the form inputs.
